### PR TITLE
add optional per-page CSS and JS, right-side footer, and image alts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ theme = "hugo-dpsg"
   mainSections = ["post", "blog", "news"] # Specify section pages to show on home page and the "Recent articles" widget
   photosSections = ["photos"] # Specify section pages to show on home page and the "Recent photos" widget
   dateformat = "02.01.2006" # Change the format of dates
-  customCSS = ["css/custom.css"] # Include custom CSS files
+  customCSS = ["css/custom.css"] # Include custom CSS files, can also be used per-page as front matter attribute
   customJS = ["js/custom.js"] # Include custom JS files
   customPartial = "piwik.html" # Include custom partials, e.g. tracking codes
 
@@ -99,6 +99,7 @@ theme = "hugo-dpsg"
 
 [Params.logo]
   image = "img/placeholder.png" # Logo image. Path relative to "static"
+  #image_alt = "Logo image" # alt value for logo image, be screen reader friendly!
   header = "img/header.jpg" # Header image. Path relative to "static"
   title = "DPSG local group" # Logo title, otherwise will use site title
   subtitle = "Welcome to our group site" # Logo subtitle
@@ -114,7 +115,7 @@ theme = "hugo-dpsg"
 
 [Params.footer]
   text = "[Imprint and Privacy](/imprint)" # Extra text in footer row, understands markdown
-  right = "Donate!" # Right-aligned text in footer row, understands markdown
+  right = "Donate!" # Right-aligned text in footer row, optional, understands markdown
 
 [Params.widgets]
   recent_num = 5 # Set the number of articles in the "Recent articles" widget
@@ -168,6 +169,7 @@ menu: main # Optional, add page to a menu. Options: main, side, footer
 
 # Theme-Defined params
 thumbnail: "img/placeholder.jpg" # Thumbnail image
+#thumbnail_alt: "Thumbnail" # alt value for thumbnail image, be screen reader friendly!
 thumbnail_hide_post: false # Hide thumbnail on single post view
 lead: "Example lead - highlighted near the title" # Lead text
 authorbox: true # Enable authorbox for specific page
@@ -179,6 +181,10 @@ widgets: # Enable sidebar widgets in given order per page
   - "recent"
   - "taglist"
 sitemap_hide: false # Do not add this page to the sitemap
+scripts_head: # optional: include some literal <head> matter, e.g. for page-specific JS imports; safeHTML-filtered
+  - "<!-- -->"
+scripts_body: # optional: include some literal html just before <body/> tag, e.g. JS initialization; safeHTML-filtered
+  - "<!-- -->"
 ---
 ```
 
@@ -243,7 +249,7 @@ your `config.toml`. Here is an example.
 
 **Note:** You need to put your icon file in `layouts/partials` directory under your
 project's root if you want to display an icon of your social link. The `icon`
-filed, which is optional, should be a path relative to `layouts/partials`.
+field, which is optional, should be a path relative to `layouts/partials`.
 
 **Note:** *Only* SVG files are supported to be used as custom social icons in the current
 version. If you use any files of another format, PNG for example, a compile

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ theme = "hugo-dpsg"
 
 [Params.footer]
   text = "[Imprint and Privacy](/imprint)" # Extra text in footer row, understands markdown
+  right = "Donate!" # Right-aligned text in footer row, understands markdown
 
 [Params.widgets]
   recent_num = 5 # Set the number of articles in the "Recent articles" widget

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ theme = "hugo-dpsg"
 
 [Params.logo]
   image = "img/placeholder.png" # Logo image. Path relative to "static"
-  #image_alt = "Logo image" # alt value for logo image, be screen reader friendly!
+  image_alt = "Logo image" # alt text for logo image, be screen reader friendly!
   header = "img/header.jpg" # Header image. Path relative to "static"
   title = "DPSG local group" # Logo title, otherwise will use site title
   subtitle = "Welcome to our group site" # Logo subtitle
@@ -169,7 +169,7 @@ menu: main # Optional, add page to a menu. Options: main, side, footer
 
 # Theme-Defined params
 thumbnail: "img/placeholder.jpg" # Thumbnail image
-#thumbnail_alt: "Thumbnail" # alt value for thumbnail image, be screen reader friendly!
+thumbnail_alt: "Thumbnail" # alt text for thumbnail image, be screen reader friendly!
 thumbnail_hide_post: false # Hide thumbnail on single post view
 lead: "Example lead - highlighted near the title" # Lead text
 authorbox: true # Enable authorbox for specific page

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -49,6 +49,7 @@ theme = "hugo-dpsg"
 
 [Params.footer]
   text = "[Imprint and Privacy](/imprint)" # Extra text in footer row, understands markdown
+  right = "Donate!" # Right-aligned text in footer row, understands markdown
 
 # Custom menu items, normally controlled via front matter in /content files
 [menu]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,9 +50,6 @@
 		</div>
 		{{ partial "sidebar.html" . }}
 	</div>
-	{{- if .Params.partial_pre_footer }}
-		{{ partial .Params.partial_pre_footer . }}
-	{{- end }}
 	{{ partial "footer" . }}
 	<script async defer src="{{ "js/menu.js" | relURL }}"></script>
 	{{ range .Site.Params.customJS -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,7 +19,10 @@
 
 	{{ $style := resources.Get "css/style.css" | resources.ExecuteAsTemplate "css/style.css" . -}}
 	<link rel="stylesheet" href="{{ $style.RelPermalink }}">
-	{{ range .Site.Params.customCSS -}}
+	{{- range .Site.Params.customCSS }}
+	<link rel="stylesheet" href="{{ . | relURL }}">
+	{{- end }}
+	{{- range .Params.customCSS }}
 	<link rel="stylesheet" href="{{ . | relURL }}">
 	{{- end }}
 
@@ -27,7 +30,8 @@
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 	{{- end }}
 
-	<link rel="shortcut icon" href="{{ "favicon.ico" | absURL }}">
+	{{ partial "favicon" . }}
+	{{ partial "perpagehead" . }}
 	{{- if not .Site.IsServer }}
 		{{ template "_internal/google_analytics_async.html" . }}
 	{{- end }}
@@ -46,11 +50,15 @@
 			</div>
 			{{ partial "sidebar.html" . }}
 		</div>
+		{{- if .Params.partial_pre_footer }}
+			{{ partial .Params.partial_pre_footer . }}
+		{{- end }}
 		{{ partial "footer" . }}
 <script async defer src="{{ "js/menu.js" | relURL }}"></script>
 {{ range .Site.Params.customJS -}}
 <script src="{{ . | relURL }}"></script>
 {{- end }}
 {{ with .Site.Params.customPartial }}{{ partial . }}{{ end }}
+{{ partial "perpagebody" . }}
 </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,14 +20,14 @@
 	{{ $style := resources.Get "css/style.css" | resources.ExecuteAsTemplate "css/style.css" . -}}
 	<link rel="stylesheet" href="{{ $style.RelPermalink }}">
 	{{- range .Site.Params.customCSS }}
-	<link rel="stylesheet" href="{{ . | relURL }}">
+		<link rel="stylesheet" href="{{ . | relURL }}">
 	{{- end }}
 	{{- range .Params.customCSS }}
-	<link rel="stylesheet" href="{{ . | relURL }}">
+		<link rel="stylesheet" href="{{ . | relURL }}">
 	{{- end }}
 
 	{{- with .OutputFormats.Get "rss" }}
-	{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
+		{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 	{{- end }}
 
 	{{ partial "favicon" . }}
@@ -37,28 +37,28 @@
 	{{- end }}
 </head>
 <body class="body">
-		{{ partial "header" . }}
-		<div class="container wrapper flex">
-			<div class="primary">
-			{{ block "main" . }}
-				{{ with .Content }}
-				<div class="content main__content clearfix">
-					{{ . }}
-				</div>
-				{{ end }}
-			{{ end }}
+	{{ partial "header" . }}
+	<div class="container wrapper flex">
+		<div class="primary">
+		{{ block "main" . }}
+			{{ with .Content }}
+			<div class="content main__content clearfix">
+				{{ . }}
 			</div>
-			{{ partial "sidebar.html" . }}
+			{{ end }}
+		{{ end }}
 		</div>
-		{{- if .Params.partial_pre_footer }}
-			{{ partial .Params.partial_pre_footer . }}
-		{{- end }}
-		{{ partial "footer" . }}
-<script async defer src="{{ "js/menu.js" | relURL }}"></script>
-{{ range .Site.Params.customJS -}}
-<script src="{{ . | relURL }}"></script>
-{{- end }}
-{{ with .Site.Params.customPartial }}{{ partial . }}{{ end }}
-{{ partial "perpagebody" . }}
+		{{ partial "sidebar.html" . }}
+	</div>
+	{{- if .Params.partial_pre_footer }}
+		{{ partial .Params.partial_pre_footer . }}
+	{{- end }}
+	{{ partial "footer" . }}
+	<script async defer src="{{ "js/menu.js" | relURL }}"></script>
+	{{ range .Site.Params.customJS -}}
+		<script src="{{ . | relURL }}"></script>
+	{{- end }}
+	{{ with .Site.Params.customPartial }}{{ partial . }}{{ end }}
+	{{ partial "perpagebody" . }}
 </body>
 </html>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -19,11 +19,14 @@
 		<div class="list__meta meta">{{ . }}</div>
 		{{- end }}
 	</header>
+	{{- if eq .Params.summary "" }}
+	{{- else }}
 	<div class="content list__excerpt post__content clearfix">
 		{{ .Summary }}
 	</div>
+	{{- end }}
 	{{- if .Site.Params.readmore }}
-	{{- if .Truncated }}
+	{{- if .Params.Truncated }}
 	<div class="list__footer clearfix">
 		<a class="list__footer-readmore btn" href="{{ .RelPermalink }}">{{ T "read_more" }}</a>
 	</div>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -26,7 +26,7 @@
 	</div>
 	{{- end }}
 	{{- if .Site.Params.readmore }}
-	{{- if .Params.Truncated }}
+	{{- if .Truncated }}
 	<div class="list__footer clearfix">
 		<a class="list__footer-readmore btn" href="{{ .RelPermalink }}">{{ T "read_more" }}</a>
 	</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,8 +19,8 @@
 					<p class="warning__tip">{{ T "noposts_warning_tip" | safeHTML }}</p>
 				</div>
 			</div>
-		{{ end }}
-	</main>
-	{{ partial "pagination.html" . }}
-	{{ end }}
+		{{- end }}
+		{{ partial "pagination.html" . }}
+	{{- end }}
+</main>
 {{ end }}

--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,0 +1,1 @@
+<link rel="shortcut icon" href="{{ "/favicon.ico" | absURL }}">

--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="{{ "/favicon.ico" | absURL }}">
+<link rel="shortcut icon" href="{{ "favicon.ico" | absURL }}">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,5 +6,6 @@
 			<span class="footer__copyright-credits">{{ T "footer_credits" | safeHTML }}</span>
 			{{ with .Site.Params.footer.text }}<span>{{ . | markdownify }}</span>{{ end }}
 		</div>
+		{{ partial "footer_right.html" . }}
 	</div>
 </footer>

--- a/layouts/partials/footer_right.html
+++ b/layouts/partials/footer_right.html
@@ -1,0 +1,3 @@
+{{- with .Site.Params.footer.right }}
+<div class="footer__text">{{ . | markdownify }}</div>
+{{- end }}

--- a/layouts/partials/footer_right.html
+++ b/layouts/partials/footer_right.html
@@ -1,3 +1,3 @@
 {{- with .Site.Params.footer.right }}
-<div class="footer__text">{{ . | markdownify }}</div>
+<div class="footer__copyright">{{ . | markdownify }}</div>
 {{- end }}

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,6 +1,7 @@
 {{- $logoTitle := .Site.Params.logo.title | default .Site.Title -}}
 {{- $logoSubtitle := .Site.Params.logo.subtitle | default .Site.Params.subtitle -}}
 {{- $logoImage := .Site.Params.logo.image -}}
+{{- $logoAlt := .Site.Params.logo.image_alt -}}
 
 {{- if or $logoTitle $logoImage }}
 	{{/* Defined when logo is mixed (image + text) */}}
@@ -11,7 +12,7 @@
 			<a class="logo__link" href="{{ "" | relLangURL }}"{{ with $logoTitle }} title="{{ . }}"{{ end }} rel="home">
 				{{ with $logoImage -}}
 					<div class="logo__item logo__imagebox">
-						<img class="logo__img" src="{{ . | relURL }}">
+						<img class="logo__img" src="{{ . | relURL }}"{{ with $logoAlt }} alt="{{ . }}"{{ end }}>
 					</div>
 				{{- end -}}
 				{{ with $logoTitle -}}

--- a/layouts/partials/perpagebody.html
+++ b/layouts/partials/perpagebody.html
@@ -1,0 +1,5 @@
+	{{- with .Params.scripts_body -}}
+		{{- range . -}}
+			{{- . | safeHTML -}}
+		{{- end -}}
+	{{- end -}}

--- a/layouts/partials/perpagehead.html
+++ b/layouts/partials/perpagehead.html
@@ -1,0 +1,5 @@
+	{{- with .Params.scripts_head -}}
+		{{- range . -}}
+			{{- . | safeHTML -}}
+		{{- end -}}
+	{{- end -}}


### PR DESCRIPTION
Hello,
thanks for this nice and clean Hugo Theme.

I am in the process of applying this to a local non-commercial sports club website and I wanted to have the "Imprint" in the footer line *right-aligned*.

The amendment introduces a new config parameter. It is optional. If absent the output should *not* be changed, so this change should be backwards compatible. I made the right side into a partial (like the optional "links" on the left side). A CSS id is assigned, but undefined, and can be used for styling.

Documentation and sample site amended, it shows "Donate!" there, just as an example.

Danke,
Matthias