### PR TITLE
fix Google analytics template reference

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -35,7 +35,7 @@
 	{{ partial "favicon" . }}
 	{{ partial "perpagehead" . }}
 	{{- if not .Site.IsServer }}
-		{{ template "_internal/google_analytics_async.html" . }}
+		{{ template "_internal/google_analytics.html" . }}
 	{{- end }}
 </head>
 <body class="body">


### PR DESCRIPTION
to be compatible with Hugo 0.125.0 release: https://github.com/gohugoio/hugo/releases/tag/v0.125.0

See here as well: https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410