### PR TITLE
Address Hugo deprecations

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,7 +34,7 @@
 
 	{{ partial "favicon" . }}
 	{{ partial "perpagehead" . }}
-	{{- if not .Site.IsServer }}
+	{{- if not hugo.IsServer }}
 		{{ template "_internal/google_analytics_async.html" . }}
 	{{- end }}
 </head>

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,4 +1,4 @@
-{{ if and .Site.DisqusShortname (index .Params "comments" | default "true") (not .Site.IsServer) }}
+{{ if and .Site.Config.Services.Disqus.Shortname (index .Params "comments" | default "true") (not hugo.IsServer) }}
 <section class="comments">
 	{{ template "_internal/disqus.html" . }}
 </section>


### PR DESCRIPTION
```
WARN  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release. Use hugo.IsServer instead.
WARN  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```