### PR TITLE
Use relURL instead of absURL

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -50,8 +50,8 @@ section {
   font-style: normal;
   font-weight: 300;
   src: local('Open Sans Light'), local('OpenSans-Light'),
-       url('{{ "fonts/open-sans-v18-latin-300.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "fonts/open-sans-v18-latin-300.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "fonts/open-sans-v18-latin-300.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "fonts/open-sans-v18-latin-300.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-300italic - latin */
@@ -60,8 +60,8 @@ section {
   font-style: italic;
   font-weight: 300;
   src: local('Open Sans Light Italic'), local('OpenSans-LightItalic'),
-       url('{{ "/fonts/open-sans-v18-latin-300italic.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-300italic.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-300italic.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-300italic.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-regular - latin */
@@ -70,8 +70,8 @@ section {
   font-style: normal;
   font-weight: 400;
   src: local('Open Sans Regular'), local('OpenSans-Regular'),
-       url('{{ "/fonts/open-sans-v18-latin-regular.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-regular.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-regular.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-regular.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-italic - latin */
@@ -80,8 +80,8 @@ section {
   font-style: italic;
   font-weight: 400;
   src: local('Open Sans Italic'), local('OpenSans-Italic'),
-       url('{{ "/fonts/open-sans-v18-latin-italic.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-italic.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-italic.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-italic.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-600 - latin */
@@ -90,8 +90,8 @@ section {
   font-style: normal;
   font-weight: 600;
   src: local('Open Sans SemiBold'), local('OpenSans-SemiBold'),
-       url('{{ "/fonts/open-sans-v18-latin-600.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-600.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-600.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-600.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-600italic - latin */
@@ -100,8 +100,8 @@ section {
   font-style: italic;
   font-weight: 600;
   src: local('Open Sans SemiBold Italic'), local('OpenSans-SemiBoldItalic'),
-       url('{{ "/fonts/open-sans-v18-latin-600italic.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-600italic.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-600italic.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-600italic.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-700 - latin */
@@ -110,8 +110,8 @@ section {
   font-style: normal;
   font-weight: 700;
   src: local('Open Sans Bold'), local('OpenSans-Bold'),
-       url('{{ "/fonts/open-sans-v18-latin-700.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-700.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-700.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-700.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* open-sans-700italic - latin */
@@ -120,8 +120,8 @@ section {
   font-style: italic;
   font-weight: 700;
   src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'),
-       url('{{ "/fonts/open-sans-v18-latin-700italic.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/open-sans-v18-latin-700italic.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/open-sans-v18-latin-700italic.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/open-sans-v18-latin-700italic.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* merriweather-regular - latin */
@@ -130,8 +130,8 @@ section {
   font-style: normal;
   font-weight: 400;
   src: local('Merriweather Regular'), local('Merriweather-Regular'),
-       url('{{ "/fonts/merriweather-v22-latin-regular.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/merriweather-v22-latin-regular.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/merriweather-v22-latin-regular.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/merriweather-v22-latin-regular.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* merriweather-700 - latin */
@@ -140,8 +140,8 @@ section {
   font-style: normal;
   font-weight: 700;
   src: local('Merriweather Bold'), local('Merriweather-Bold'),
-       url('{{ "/fonts/merriweather-v22-latin-700.woff2" | absURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('{{ "/fonts/merriweather-v22-latin-700.woff" | absURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('{{ "/fonts/merriweather-v22-latin-700.woff2" | relURL }}') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('{{ "/fonts/merriweather-v22-latin-700.woff" | relURL }}') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 

--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="{{ "favicon.ico" | absURL }}">
+<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">


### PR DESCRIPTION
I have a small website which is configured for multiple URLs, e.g. www.myexample.com, myexample.com, and my-example.com. All of the URLs are relative so it doesn't matter only a few of them are absolute. They always link to `baseURL` of the config. This only affects fonts and the favicon.

In this PR I adapted them to a relative URL. I didn't notice any issues so far.

I also checked on Mainroad and they also use a relative link:
```html
<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
```
https://github.com/Vimux/Mainroad/blob/86f1b1987c68ebe429be3e9e801af6dbb98d2d0c/layouts/_default/baseof.html#L37