### PR TITLE
display "read more" button when there is a summary

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -26,7 +26,7 @@
 	</div>
 	{{- end }}
 	{{- if .Site.Params.readmore }}
-	{{- if .Truncated }}
+	{{- if or (.Truncated) (not (eq .Params.summary "")) }}
 	<div class="list__footer clearfix">
 		<a class="list__footer-readmore btn" href="{{ .RelPermalink }}">{{ T "read_more" }}</a>
 	</div>


### PR DESCRIPTION
Before, the "read more" button in the list of articles was only displayed when the generated preview text was explicitly truncated. With that change, the "read more" button will always be displayed when an explicit summary is provided.

Without any explicit summary in the page header, nothing changes.

The assumption is, that an explicitly provided summary always differs from the actual page content. With that, a "read more" button always makes sense in such a case.