### PR TITLE
FIX: deprecated .Site.Author

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ DefaultContentLanguage = "de"
 paginate = "10" # Number of posts per page
 theme = "hugo-dpsg"
 
-[Author] # Used in authorbox
-  name = "Scout Master"
-  bio = "The Scout Master is the leader of this local scout group"
-  avatar = "img/avatar.png"
-
 [Params]
   description = "Welcome to our scout group!" # Site description. Used in meta description
   copyright = "DGSP local group" # Footer copyright holder, otherwise will use site title
@@ -95,6 +90,11 @@ theme = "hugo-dpsg"
   customJS = ["js/custom.js"] # Include custom JS files
   customPartial = "piwik.html" # Include custom partials at the end of the page, e.g. tracking codes
   belowTitlePartial = "alert.html" # Include custom partial below the pages title
+
+[Params.Author] # Used in authorbox
+  name = "Scout Master"
+  bio = "The Scout Master is the leader of this local scout group"
+  avatar = "img/avatar.png"
 
 [Params.style.vars]
   highlightColor = "#003056" # Override main theme color

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,11 +5,6 @@ DefaultContentLanguage = "de"
 paginate = "10" # Number of posts per page
 theme = "hugo-dpsg"
 
-[Author] # Used in authorbox
-  name = "Scout Master"
-  bio = "The Scout Master is the leader of this local scout group"
-  avatar = "img/avatar.png"
-
 [Params]
   description = "Welcome to our scout group!" # Site description. Used in meta description
   copyright = "DGSP local group" # Footer copyright holder, otherwise will use site title
@@ -24,6 +19,11 @@ theme = "hugo-dpsg"
   post_meta = ["author", "date", "categories", "translations"] # Order of post meta information
   mainSections = ["post", "blog", "news"] # Specify section pages to show on home page and the "Recent articles" widget
   dateformat = "02.01.2006" # Change the format of dates
+
+[Params.Author] # Used in authorbox
+  name = "Scout Master"
+  bio = "The Scout Master is the leader of this local scout group"
+  avatar = "img/avatar.png"
 
 [Params.style.vars]
   highlightColor = "#003056" # Override main theme color

--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -1,21 +1,21 @@
 {{- if .Param "authorbox" }}
 <div class="authorbox clearfix">
-	{{- if and (not .Site.Author.avatar) (not .Site.Author.name) (not .Site.Author.bio) }}
+	{{- if and (not .Site.Params.Author.avatar) (not .Site.Params.Author.name) (not .Site.Params.Author.bio) }}
 	<p class="authorbox__warning">
 		<strong>WARNING:</strong> Authorbox is activated, but [Author] parameters are not specified.
 	</p>
 	{{- end }}
-	{{- with .Site.Author.avatar }}
+	{{- with .Site.Params.Author.avatar }}
 	<figure class="authorbox__avatar">
-		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | relURL }}" class="avatar" height="90" width="90">
+		<img alt="{{ $.Site.Params.Author.name }} avatar" src="{{ $.Site.Params.Author.avatar | relURL }}" class="avatar" height="90" width="90">
 	</figure>
 	{{- end }}
-	{{- with .Site.Author.name }}
+	{{- with .Site.Params.Author.name }}
 	<div class="authorbox__header">
 		<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
 	</div>
 	{{- end }}
-	{{- with .Site.Author.bio }}
+	{{- with .Site.Params.Author.bio }}
 	<div class="authorbox__description">
 		{{ . | markdownify }}
 	</div>

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,6 +1,6 @@
-{{- if .Site.Author.name -}}
+{{- if .Site.Params.Author.name -}}
 <div class="meta__item-author meta__item">
 	{{ partial "svg/author.svg" (dict "class" "meta__icon") -}}
-	<span class="meta__text">{{ .Site.Author.name }}</span>
+	<span class="meta__text">{{ .Site.Params.Author.name }}</span>
 </div>
 {{- end -}}


### PR DESCRIPTION
This will fix the deprecation Error:

> ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Implement taxonomy 'author' or use .Site.Params.Author instead.