### PR TITLE
ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.…

### DIFF
--- a/layouts/partials/widgets/languages.html
+++ b/layouts/partials/widgets/languages.html
@@ -1,5 +1,5 @@
 {{- $translations := .Site.Home.AllTranslations }}
-{{- if and hugo.IsMultiLingual (gt (len $translations) 0) }}
+{{- if and hugo.IsMultilingual (gt (len $translations) 0) }}
 <div class="widget-languages widget">
 	<h4 class="widget__title">{{ T "languages_title" }}</h4>
 	<div class="widget__content">

--- a/layouts/partials/widgets/languages.html
+++ b/layouts/partials/widgets/languages.html
@@ -1,5 +1,5 @@
 {{- $translations := .Site.Home.AllTranslations }}
-{{- if and .Site.IsMultiLingual (gt (len $translations) 0) }}
+{{- if and hugo.IsMultiLingual (gt (len $translations) 0) }}
 <div class="widget-languages widget">
 	<h4 class="widget__title">{{ T "languages_title" }}</h4>
 	<div class="widget__content">


### PR DESCRIPTION
Hello，When i used hugo to build my github pages on MacOS, i found this error:

"ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.140.0. Use hugo.IsMultilingual instead. "

hugo version: 
hugo v0.139.3+extended+withdeploy darwin/arm64 BuildDate=2024-11-29T15:36:56Z VendorInfo=brew