### PR TITLE
Add client-side search widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ theme = "hugo-dpsg"
   single = false # Configure layout for single pages
   # Enable widgets in given order
   widgets = ["search", "recent", "recent_photos", "recent_photos_tags", "categories", "taglist", "social", "languages"]
-  # alternatively "ddg-search" can be used, to search via DuckDuckGo or "local-search" to use a client side search widget
+  # alternatively "ddg-search" can be used, to search via DuckDuckGo or "local-search" to use a client side search widget (WARNING: On big websites the local search can cause high traffic)
   # widgets = ["ddg-search", "recent", "categories", "taglist", "social", "languages"]
 
 [Params.footer]

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ theme = "hugo-dpsg"
   single = false # Configure layout for single pages
   # Enable widgets in given order
   widgets = ["search", "recent", "recent_photos", "recent_photos_tags", "categories", "taglist", "social", "languages"]
-  # alternatively "ddg-search" can be used, to search via DuckDuckGo
+  # alternatively "ddg-search" can be used, to search via DuckDuckGo or "local-search" to use a client side search widget
   # widgets = ["ddg-search", "recent", "categories", "taglist", "social", "languages"]
 
 [Params.footer]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ DefaultContentLanguage = "de"
 paginate = "10" # Number of posts per page
 theme = "hugo-dpsg"
 
+[markup.goldmark.renderer] # Needed if using the local-search widget
+  hardWraps = false
+  unsafe = true
+  xhtml = false
+
 [outputs] # Needed if using the local-search widget
   home = ["HTML", "RSS", "JSON"]
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,6 @@ DefaultContentLanguage = "de"
 paginate = "10" # Number of posts per page
 theme = "hugo-dpsg"
 
-[markup.goldmark.renderer] # Needed if using the local-search widget
-  hardWraps = false
-  unsafe = true
-  xhtml = false
-
 [outputs] # Needed if using the local-search widget
   home = ["HTML", "RSS", "JSON"]
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ DefaultContentLanguage = "de"
 paginate = "10" # Number of posts per page
 theme = "hugo-dpsg"
 
+[outputs] # Needed if using the local-search widget
+  home = ["HTML", "RSS", "JSON"]
+
 [Params]
   description = "Welcome to our scout group!" # Site description. Used in meta description
   copyright = "DGSP local group" # Footer copyright holder, otherwise will use site title

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,6 +9,9 @@ themesDir = "../.."
 languageCode = "en"
 DefaultContentLanguage = "en"
 
+[outputs] # Needed if using the local-search widget
+  home = ["HTML", "RSS", "JSON"]
+
 [permalinks]
   news = "post/:year/:slug/"
   fotos = "fotos/:year/:slug/"
@@ -51,7 +54,7 @@ DefaultContentLanguage = "en"
   list = "left"  # Configure layout for list pages
   single = false # Configure layout for single pages
   # Enable widgets in given order
-  widgets = ["search", "recent", "categories", "taglist", "social", "languages"]
+  widgets = ["local-search", "recent", "categories", "taglist", "social", "languages"]
   # alternatively "ddg-search" can be used, to search via DuckDuckGo
   # widgets = ["ddg-search", "recent", "categories", "taglist", "social", "languages"]
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -55,7 +55,7 @@ DefaultContentLanguage = "en"
   single = false # Configure layout for single pages
   # Enable widgets in given order
   widgets = ["local-search", "recent", "categories", "taglist", "social", "languages"]
-  # alternatively "ddg-search" can be used, to search via DuckDuckGo
+  # alternatively "ddg-search" can be used, to search via DuckDuckGo or "search" can be used, to search via Google. "local-search" provides a client side search widget (WARNING: On big websites the local search can cause high traffic)
   # widgets = ["ddg-search", "recent", "categories", "taglist", "social", "languages"]
 
 [Params.widgets]

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,0 +1,8 @@
+{{/* layouts/_default/index.json */}}
+{{- $index := slice -}}
+{{- range where .Site.RegularPages.ByDate.Reverse "Type" "not in" (slice "page" "json") -}}
+    {{- $summary := .Content | plainify | truncate 100 -}}
+    {{- $shortTitle := .Title | truncate 10 -}}
+    {{- $index = $index | append (dict "title" (.Title | plainify) "permalink" .Permalink "content" .Content "summary" $summary "shortTitle" $shortTitle "categories" .Params.categories) -}}
+{{- end -}}
+{{- $index | jsonify -}}

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,9 +1,7 @@
 {{/* layouts/_default/index.json */}}
 {{- $index := slice -}}
-{{- range where .Site.RegularPages.ByDate.Reverse "Type" "not in" (slice "page" "json") -}}
-    {{- $summary := .Content | plainify | truncate 100 -}}
-    {{- $shortTitle := .Title | truncate 10 -}}
+{{- range where .Site.RegularPages.ByDate.Reverse "Type" "not in" (slice "json") -}}
     {{- $content := .Content | plainify -}}
-    {{- $index = $index | append (dict "title" (.Title | plainify) "permalink" .Permalink "content" $content "summary" $summary "shortTitle" $shortTitle "categories" .Params.categories) -}}
+    {{- $index = $index | append (dict "title" (.Title | plainify) "permalink" .Permalink "content" $content "categories" .Params.categories) -}}
 {{- end -}}
 {{- $index | jsonify -}}

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -3,6 +3,7 @@
 {{- range where .Site.RegularPages.ByDate.Reverse "Type" "not in" (slice "page" "json") -}}
     {{- $summary := .Content | plainify | truncate 100 -}}
     {{- $shortTitle := .Title | truncate 10 -}}
-    {{- $index = $index | append (dict "title" (.Title | plainify) "permalink" .Permalink "content" .Content "summary" $summary "shortTitle" $shortTitle "categories" .Params.categories) -}}
+    {{- $content := .Content | plainify -}}
+    {{- $index = $index | append (dict "title" (.Title | plainify) "permalink" .Permalink "content" $content "summary" $summary "shortTitle" $shortTitle "categories" .Params.categories) -}}
 {{- end -}}
 {{- $index | jsonify -}}

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -85,8 +85,17 @@
                         let title = (page.title || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
 
                         searchTerms.forEach(term => {
-                            if (title.includes(term)) score += 5; // Higher weight for title matches
-                            if (content.includes(term)) score += 1; // Lower weight for content matches
+                            // Count matches
+                            let titleMatches = (title.match(new RegExp(term, "g")) || []).length;
+                            let contentMatches = (content.match(new RegExp(term, "g")) || []).length;
+
+                            // logarithmic calculation of the scores
+                            if (titleMatches > 0) {
+                                score += 5 * Math.log(titleMatches + 1);
+                            }
+                            if (contentMatches > 0) {
+                                score += 1 * Math.log(contentMatches + 1);
+                            }
                         });
 
                         return { ...page, score };

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -13,24 +13,6 @@
 </div>
 
 <style>
-    /* Widget container styling */
-    .widget {
-        background: #ffffff;
-        border: 1px solid #ddd;
-        padding: 20px;
-        margin-bottom: 20px;
-        border-radius: 5px;
-        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-    }
-
-    /* Title styling */
-    .widget__title {
-        font-size: 1.25rem;
-        font-weight: bold;
-        color: {{ .Site.Params.style.vars.highlightColor }}; /* Set theme color */
-        margin-bottom: 15px;
-    }
-
     /* Input styling */
     .search-input {
         width: 100%;
@@ -52,7 +34,6 @@
     .search-results-item {
         margin-bottom: 10px;
         padding: 10px;
-        background-color: #f9f9f9;
         border: 1px solid #ddd;
         border-radius: 4px;
     }

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -47,6 +47,12 @@
     .search-results-item a:hover {
         text-decoration: underline;
     }
+    .highlight {
+        color: {{ .Site.Params.style.vars.highlightColor }}; /* Set theme color */
+        font-weight: bold;
+        text-decoration: underline;
+    }
+
 </style>
 
 <script>
@@ -64,28 +70,79 @@
                 results.innerHTML = "";
 
                 if (input.value !== "") {
-                    let searchTerms = input.value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().split(" ");
+                    let searchTerms = input.value
+                        .normalize("NFD")
+                        .replace(/[\u0300-\u036f]/g, "")
+                        .toLowerCase()
+                        .split(" ");
 
-                    searchTerms.forEach(function (term) {
-                        filteredPages = filteredPages.filter(function (page) {
-                            let content = page.content || "";  // Ensure we're searching the full content
-                            return content.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().includes(term);
+                    // Calculate relevance scores
+                    filteredPages = filteredPages.map(function (page) {
+                        let score = 0;
+                        let content = (page.content || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+                        let title = (page.title || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+
+                        searchTerms.forEach(term => {
+                            if (title.includes(term)) score += 5; // Higher weight for title matches
+                            if (content.includes(term)) score += 1; // Lower weight for content matches
                         });
+
+                        return { ...page, score };
                     });
 
+                    // Filter and sort by relevance
+                    filteredPages = filteredPages
+                        .filter(page => page.score > 0)
+                        .sort((a, b) => b.score - a.score);
+
+                    // Highlight matches and create dynamic summaries
                     filteredPages.forEach(function (page) {
+                        let highlightedTitle = highlightTerms(page.title, searchTerms);
+                        let dynamicSummary = createDynamicSummary(page.content, searchTerms);
+
                         results.insertAdjacentHTML(
                             "beforeend",
                             `<li class='search-results-item'>
                                 <h2 style='font-size: 1.5rem;'>
-                                    <a href='${page.permalink}' title='${page.title}'>${page.shortTitle}</a> <!-- Tooltip for full title -->
+                                    <a href='${page.permalink}' title='${page.title}'>${highlightedTitle}</a>
                                 </h2>
-                                <p>${page.summary}</p>  <!-- Display the summary as before -->
+                                <p>${dynamicSummary}</p>
                             </li>`
                         );
                     });
                 }
             });
+
+            // Function to highlight terms
+            function highlightTerms(text, terms) {
+                terms.forEach(term => {
+                    let regex = new RegExp(`(${term})`, "gi");
+                    text = text.replace(regex, "<span class='highlight'>$1</span>");
+                });
+                return text;
+            }
+
+            // Function to create a dynamic summary with highlighted terms
+            function createDynamicSummary(content, terms) {
+                content = content.normalize("NFD").replace(/[\u0300-\u036f]/g, ""); // Normalize content
+                let lowerContent = content.toLowerCase();
+                let matchIndex = -1;
+
+                // Find the first occurrence of any term
+                terms.some(term => {
+                    matchIndex = lowerContent.indexOf(term.toLowerCase());
+                    return matchIndex !== -1;
+                });
+
+                if (matchIndex === -1) return ""; // No match found
+
+                // Extract context around the match
+                let start = Math.max(matchIndex - 30, 0); // 30 characters before the match
+                let end = Math.min(matchIndex + 70, content.length); // 70 characters after the match
+                let snippet = content.slice(start, end);
+
+                // Highlight the terms in the snippet
+                return highlightTerms(snippet, terms) + (end < content.length ? "..." : "");
+            }
         });
 </script>
-

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -106,6 +106,8 @@
                         .filter(page => page.score > 0)
                         .sort((a, b) => b.score - a.score);
 
+                    filteredPages = filteredPages.slice(0, 10);
+
                     // Highlight matches and create dynamic summaries
                     filteredPages.forEach(function (page) {
                         let highlightedTitle = highlightTerms(page.title, searchTerms);

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -52,7 +52,6 @@
         font-weight: bold;
         text-decoration: underline;
     }
-
 </style>
 
 <script>
@@ -69,12 +68,15 @@
                 let filteredPages = pages;
                 results.innerHTML = "";
 
-                if (input.value !== "") {
+                if (input.value.trim() !== "") { // Check if the input is not just spaces
                     let searchTerms = input.value
                         .normalize("NFD")
                         .replace(/[\u0300-\u036f]/g, "")
                         .toLowerCase()
-                        .split(" ");
+                        .split(" ")
+                        .filter(term => term.trim().length > 0); // Ignore empty or invalid terms
+
+                    if (searchTerms.length === 0) return; // Exit if no valid search terms
 
                     // Calculate relevance scores
                     filteredPages = filteredPages.map(function (page) {

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -118,7 +118,7 @@
             // Function to highlight terms
             function highlightTerms(text, terms) {
                 terms.forEach(term => {
-                    let regex = new RegExp(`(${term})`, "gi");
+                    let regex = new RegExp(`(${term})(?![^<]*>)`, "gi");
                     text = text.replace(regex, "<span class='highlight'>$1</span>");
                 });
                 return text;

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -57,7 +57,10 @@
 <script>
     const input = document.getElementById("search-input");
     const results = document.getElementById("search-results");
-    const request = new Request("/index.json");
+
+    // Create a cache-busting query parameter using the current timestamp
+    const cacheBuster = new Date().getTime();
+    const request = new Request(`/index.json?timestamp=${cacheBuster}`);
 
     fetch(request)
         .then(response => response.json())

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -1,0 +1,110 @@
+<div class="widget widget-search">
+    <h4 class="widget__title">{{ T "search_placeholder" }}</h4>
+    <div class="widget__content">
+        <input
+            type="text"
+            id="search-input"
+            placeholder="{{ T "search_placeholder" }}"
+            aria-label="{{ T "search_placeholder" }}"
+            class="search-input"
+        >
+        <ul id="search-results" class="search-results"></ul>
+    </div>
+</div>
+
+<style>
+    /* Widget container styling */
+    .widget {
+        background: #ffffff;
+        border: 1px solid #ddd;
+        padding: 20px;
+        margin-bottom: 20px;
+        border-radius: 5px;
+        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Title styling */
+    .widget__title {
+        font-size: 1.25rem;
+        font-weight: bold;
+        color: {{ .Site.Params.style.vars.highlightColor }}; /* Set theme color */
+        margin-bottom: 15px;
+    }
+
+    /* Input styling */
+    .search-input {
+        width: 100%;
+        padding: 10px;
+        font-size: 1rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        margin-bottom: 15px;
+        box-sizing: border-box;
+    }
+
+    /* Results list styling */
+    .search-results {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .search-results-item {
+        margin-bottom: 10px;
+        padding: 10px;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+    }
+
+    .search-results-item a {
+        font-weight: bold;
+        color: {{ .Site.Params.style.vars.highlightColor }}; /* Set theme color */
+        text-decoration: none;
+    }
+
+    .search-results-item a:hover {
+        text-decoration: underline;
+    }
+</style>
+
+<script>
+    const input = document.getElementById("search-input");
+    const results = document.getElementById("search-results");
+    const request = new Request("/index.json");
+
+    fetch(request)
+        .then(response => response.json())
+        .then(data => {
+            let pages = data;
+
+            input.addEventListener("input", function () {
+                let filteredPages = pages;
+                results.innerHTML = "";
+
+                if (input.value !== "") {
+                    let searchTerms = input.value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().split(" ");
+
+                    searchTerms.forEach(function (term) {
+                        filteredPages = filteredPages.filter(function (page) {
+                            let content = page.content || "";  // Ensure we're searching the full content
+                            return content.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().includes(term);
+                        });
+                    });
+
+                    filteredPages.forEach(function (page) {
+                        results.insertAdjacentHTML(
+                            "beforeend",
+                            `<li class='search-results-item'>
+                                <h2 style='font-size: 1.5rem;'>
+                                    <a href='${page.permalink}' title='${page.title}'>${page.shortTitle}</a> <!-- Tooltip for full title -->
+                                </h2>
+                                <p>${page.summary}</p>  <!-- Display the summary as before -->
+                            </li>`
+                        );
+                    });
+                }
+            });
+        });
+</script>
+

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -22,6 +22,11 @@
         border-radius: 4px;
         margin-bottom: 15px;
         box-sizing: border-box;
+		outline: none;
+    }
+
+    .search-input:focus {
+        box-shadow: inset 0 0 0 1% black;
     }
 
     /* Results list styling */

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -1,4 +1,4 @@
-<div class="widget widget-search">
+<div class="widget-search widget">
     <h4 class="widget__title">{{ T "search_placeholder" }}</h4>
     <div class="widget__content">
         <input

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -22,7 +22,7 @@
         border-radius: 4px;
         margin-bottom: 15px;
         box-sizing: border-box;
-		outline: none;
+	outline: none;
     }
 
     .search-input:focus {

--- a/layouts/partials/widgets/local-search.html
+++ b/layouts/partials/widgets/local-search.html
@@ -26,7 +26,7 @@
     }
 
     .search-input:focus {
-        box-shadow: inset 0 0 0 1% black;
+        box-shadow: inset 0 0 0 1px black;
     }
 
     /* Results list styling */


### PR DESCRIPTION
This pull request adds a client-side search widget to the theme, allowing users to search content directly on the site. The widget uses JavaScript to filter and display results from a generated `index.json` file. 

#### Key Changes:
- Added `local-search.html` partial for search input, results display, and styling. You might have to check the css styling in local-search.html. I am not sure if I have the minimal approach to it.
- Added the `index.json` file to gather informations of all posts for the search script.

#### Note:
- **Performance Warning**: On large websites with many pages, this client-side search might increase traffic and slow down performance due to the large `index.json` file size. Consider server-side search solutions for bigger sites, maybe we need to add a warning to the README? I tried to minimize the size of the index.json by plainifying the content but it still contains the text of all posts.